### PR TITLE
#113 added close to http requests

### DIFF
--- a/lib/SolrUpdater.py
+++ b/lib/SolrUpdater.py
@@ -40,6 +40,8 @@ def delete_by_bibcodes(bibcodes,dryrun=False,urls=SOLR_URLS):
       continue
     for url in urls:
       r = requests.post(url,headers=headers,data=data)
+      if r.status_code == 200:
+        r.close()  # do not close on error to preserve state for raise
     r.raise_for_status()
     m.remove({'bibcode':bibcode})
 
@@ -762,6 +764,7 @@ def solrUpdate(bibcodes,urls=SOLR_URLS, on_dbfailure_retry=True):
   for url in urls:
     logger.info("Posting payload of length %s to %s" % (len(solrRecords),url))
     r = requests.post(url,data=payload,headers=headers)
+    r.close()
 
 def main():
   parser = argparse.ArgumentParser()

--- a/tests/tests/testSolrUpdater.py
+++ b/tests/tests/testSolrUpdater.py
@@ -7,8 +7,6 @@ sys.path.append(os.path.join(PROJECT_HOME,'tests'))
 
 from lib import SolrUpdater
 from stubdata import stubdata
-from settings import MONGO
-from requests.exceptions import InvalidSchema
 
 
 class TestSolrAdapter(unittest.TestCase):
@@ -54,23 +52,6 @@ class TestBibstemMapper(unittest.TestCase):
       s, l = SolrUpdater.bibstem_mapper(t['bibcode'])
       self.assertEquals([s,l],t['bibstems'])
 
-  def tearDown(self):
-    pass
-
-class TestSolrException(unittest.TestCase):
-  def setUp(self):
-    pass
-
-  def test_delete_bibcode_exception(self):
-    MONGO['DATABASE'] = 'unittests_tmp'
-    MONGO['COLLECTION'] = 'unittests_tmp'
-    MONGO['PORT'] = '27017'
-    
-    with self.assertRaises(InvalidSchema):
-      # should call raise_for_status due to illegal url
-      SolrUpdater.delete_by_bibcodes(['2015Prmtm.book...81D'], False, ['foo://bar'])
-      
-  
   def tearDown(self):
     pass
 

--- a/tests/tests/testSolrUpdater.py
+++ b/tests/tests/testSolrUpdater.py
@@ -7,7 +7,8 @@ sys.path.append(os.path.join(PROJECT_HOME,'tests'))
 
 from lib import SolrUpdater
 from stubdata import stubdata
-
+from settings import MONGO
+from requests.exceptions import InvalidSchema
 
 
 class TestSolrAdapter(unittest.TestCase):
@@ -53,6 +54,23 @@ class TestBibstemMapper(unittest.TestCase):
       s, l = SolrUpdater.bibstem_mapper(t['bibcode'])
       self.assertEquals([s,l],t['bibstems'])
 
+  def tearDown(self):
+    pass
+
+class TestSolrException(unittest.TestCase):
+  def setUp(self):
+    pass
+
+  def test_delete_bibcode_exception(self):
+    MONGO['DATABASE'] = 'unittests_tmp'
+    MONGO['COLLECTION'] = 'unittests_tmp'
+    MONGO['PORT'] = '27017'
+    
+    with self.assertRaises(InvalidSchema):
+      # should call raise_for_status due to illegal url
+      SolrUpdater.delete_by_bibcodes(['2015Prmtm.book...81D'], False, ['foo://bar'])
+      
+  
   def tearDown(self):
     pass
 


### PR DESCRIPTION
added close to http requests so sockets are immediately recycled
which prevents socket related error 99

This code was only executed via the unit tests.  We need to run it in a test environment where a test Solr instance is available.  