### PR TITLE
changes from running bibicode through pipeline

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -116,7 +116,7 @@ queue. There the workers take over.
 
 To force an update of a list of bibcodes use the following:
 ```
-python run.py --ignore-json-fingerprints --target-bibcodes @reindex/reingest_20161122.txt
+python run.py --ignore-json-fingerprints --bibcodes @reindex/reingest_20161122.txt
 ```
 
 ## Updating Solr

--- a/run.py
+++ b/run.py
@@ -174,9 +174,6 @@ def main(*args):
 
     args = parser.parse_args()
 
-    if args.bibcodes:
-        args.bibcodes = [x.strip() for x in args.bibcodes.split(',')]
-
     # initialize cache (to read ADS records)
     if not args.dont_init_lookers_cache and read_records.INIT_LOOKERS_CACHE:
         start = time.time()
@@ -196,7 +193,8 @@ def main(*args):
                         if line.startswith('#'):
                             continue
                         b = line.strip()
-                        targets.append({b: records[b]})
+                        if b:
+                            targets.append({b: records[b]})
             else:
                 targets.append({t:records[t]})
 


### PR DESCRIPTION
--target-bibcodes changed to --bibcodes but documentation.md not updated.
I do no understand what run.py at line 177 was trying to accomplish.  when reading bibcodes from a file there are no comma separators to split on.  at line run.py line 199, a blank line at the end of a file was not handled