### PR TITLE
refactored to support unit tests when adspy is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Since the code makes use of ads.ADSCachedExports for data ingest, you will have 
 repo to test the code locally.  Until we properly write tests that mock that input, follow the
 directions given in adsabs/adspy/DEVELOP.txt for setting up adspy to read the required files from ADS Classic.
 
+libxml2 is required, you may want to install globally via brew and access via virtualenv --system-site-packages.
+
 A useful script that helps you see how the documents are transformed is found in tests/tests/readrecords.py
 
 ## Updating the code

--- a/aip/direct/ArXivDirect.py
+++ b/aip/direct/ArXivDirect.py
@@ -1,172 +1,182 @@
-import ads.ADSCachedExports as ads_ex
-import ads.journal_parser as ads_jp
-import ads.Keywords as kw_normalizer
-import ads.ArtDefs as ArtDefs
-import pyingest.parsers.arxiv as arxiv
-import pyingest.serializers.classic as classic
 
-class adsDirectRecord(ads_ex.ADSRecords):
+# on localhost:
+#  uses libxml2 via virtualenv --system-site-packages
+#  and adspy via mount of /proj
 
-    def addDirect(self, record, json_timestamp=None,current_record=None,
-            origin=None, matched_preprint=False, fulltext=None):
-
-        bibcode = record['bibcode']
-        if not bibcode:
-            raise ads_ex.InvalidBibcode('Empty bibcode.')
-
-        bibliographic_info = ads_ex.get_bibliographic_info(bibcode)
-
-# create a new record for the Direct entry
-
-        if current_record is None:
-            rec_properties = {'bibcode': bibcode,'entry_date': record['pubdate']}
-            self.current_record = ads_ex.xml_node(self.xml_records, 'record', properties=rec_properties)
-        else:
-            self.current_record = current_record
-
-# create a new metadata tag for the Direct entry abstract
-        datasource = 'ARXIV'
-        abs_properties = {'origin':datasource, 'type':'general', 'primary':'True', 'alternate_journal':'False'}
-        self.current_abstract = ads_ex.xml_node(self.current_record, 'metadata', properties = abs_properties)
+import sys
+try:
+    import ads.ADSCachedExports as ads_ex
+    import ads.journal_parser as ads_jp
+    import ads.Keywords as kw_normalizer
+    import ads.ArtDefs as ArtDefs
+except ImportError:
+    sys.path.append('/proj/ads/soft/python/lib/site-packages')
+    try:
+        import ads.ADSCachedExports as ads_ex
+        import ads.journal_parser as ads_jp
+        import ads.Keywords as kw_normalizer
+        import ads.ArtDefs as ArtDefs
+    except ImportError as e:
+        print 'Unable to import ads libraries: {}'.format(e)
 
 
-# begin creating subfields under this metadata tag
+def add_direct(record, json_timestamp=None, current_record=None,
+               origin=None, matched_preprint=False, fulltext=None):
+    """
+    return a complete ADSRecords instance from direct data with xml
+    """
+    bibcode = record['bibcode']
+    if not bibcode:
+        raise ads_ex.InvalidBibcode('Empty bibcode.')
 
-        creation_time = ads_ex.iso_8601_time(None)
-        modif_time = creation_time
-        ads_ex.xml_node(self.current_abstract, 'creation_time', creation_time)
-        ads_ex.xml_node(self.current_abstract, 'modification_time', modif_time)
+    adsr = ads_ex.ADSRecords('full', 'XML', cacheLooker=False)    
+    bibliographic_info = ads_ex.get_bibliographic_info(bibcode)
 
-        ads_ex.xml_node(self.current_abstract, 'bibcode', bibcode)
+    # create a new record for the Direct entry
 
-        (year,month,dum) = record['pubdate'].split('-')
-        dates = {'date-preprint':'%s-%s-00'%(year,month)}
-        ads_ex.add_dates(self.current_abstract, dates)
+    if current_record is None:
+        rec_properties = {'bibcode': bibcode, 'entry_date': record['pubdate']}
+        adsr.current_record = ads_ex.xml_node(adsr.xml_records, 'record', properties=rec_properties)
+    else:
+        adsr.current_record = current_record
 
-        ads_ex.xml_node(self.current_abstract, 'title', record['title'])
+    # create a new metadata tag for the Direct entry abstract
+    datasource = 'ARXIV'
+    abs_properties = {'origin': datasource, 'type': 'general', 'primary': 'True', 'alternate_journal': 'False'}
+    adsr.current_abstract = ads_ex.xml_node(adsr.current_record, 'metadata', properties=abs_properties)
 
-        abstract_field = record['abstract']
-        abstract_field = ads_ex.UNICODE_HANDLER.remove_control_chars(abstract_field)
+    # begin creating subfields under this metadata tag
+
+    creation_time = ads_ex.iso_8601_time(None)
+    modif_time = creation_time
+    ads_ex.xml_node(adsr.current_abstract, 'creation_time', creation_time)
+    ads_ex.xml_node(adsr.current_abstract, 'modification_time', modif_time)
+
+    ads_ex.xml_node(adsr.current_abstract, 'bibcode', bibcode)
+
+    (year, month, dum) = record['pubdate'].split('-')
+    dates = {'date-preprint': '%s-%s-00' % (year, month)}
+    ads_ex.add_dates(adsr.current_abstract, dates)
+
+    ads_ex.xml_node(adsr.current_abstract, 'title', record['title'])
+
+    abstract_field = record['abstract']
+    abstract_field = ads_ex.UNICODE_HANDLER.remove_control_chars(abstract_field)
+    try:
+        abstract_field = ads_ex.UNICODE_HANDLER.ent2xml(abstract_field)
+    except:
+        pass
+    ads_ex.xml_node(adsr.current_abstract, 'abstract', abstract_field.strip())
+
+    authors = ads_ex.UNICODE_HANDLER.ent2u(record['authors'])
+    authors = ads_ex.UNICODE_HANDLER.remove_control_chars(authors)
+    authors = ads_ex.RE_INITIAL.sub('. ', authors)
+    authors = authors.strip().strip(';')
+    author_number = 0
+    for index, author_name in enumerate(authors.split(';')):
+        normalized_author = ads_ex.normalize_author(author_name)
+        author_number += 1
+        author = {
+            'nr': str(author_number),
+            'western': author_name.strip(),
+            'normalized': normalized_author,
+            'affiliation': None,
+            'id': None,
+            'email': None,
+            'native': None,
+            'author_id': None,
+            'type': 'regular'
+            }
+        ads_ex.add_author(adsr.current_abstract, author, 'full')
+
+    journal = record['publication']
+    ads_ex.xml_node(adsr.current_abstract, 'journal', journal)
+
+    canonical_journal = ads_jp.get_canonical_journal(bibcode)
+    ads_ex.xml_node(adsr.current_abstract, 'canonical_journal', canonical_journal)
+
+    electronic_id = journal.replace('eprint ', '')
+    ads_ex.xml_node(adsr.current_abstract, 'electronic_id', electronic_id)
+
+    number_pages = 0
+    ads_ex.xml_node(adsr.current_abstract, 'number_pages', str(number_pages))
+
+    databases = set()
+    try:
+        field = ads_ex.UNICODE_HANDLER.ent2xml(record['keywords'])
+    except:
         try:
-            abstract_field = ads_ex.UNICODE_HANDLER.ent2xml(abstract_field)
+            field = record['keywords']
         except:
             pass
-        ads_ex.xml_node(self.current_abstract, 'abstract', abstract_field.strip())
-
-        authors = ads_ex.UNICODE_HANDLER.ent2u(record['authors'])
-        authors = ads_ex.UNICODE_HANDLER.remove_control_chars(authors)
-        authors = ads_ex.RE_INITIAL.sub('. ', authors)
-        authors = authors.strip().strip(';')
-        xml_authors = []
-        author_number = 0
-        for index, author_name in enumerate(authors.split(';')):
-            normalized_author = ads_ex.normalize_author(author_name)
-            author_number += 1
-            author = {
-                'nr': str(author_number),
-                'western': author_name.strip(),
-                'normalized': normalized_author,
-                'affiliation': None,
-                'id': None,
-                'email': None,
-                'native': None,
-                'author_id': None,
-                'type': 'regular'
-                }
-            ads_ex.add_author(self.current_abstract,author,'full')
-
-
-        
-        journal = record['publication']
-        ads_ex.xml_node(self.current_abstract,'journal',journal)
-
-        canonical_journal = ads_jp.get_canonical_journal(bibcode)
-        ads_ex.xml_node(self.current_abstract,'canonical_journal',canonical_journal)
-
-        electronic_id = journal.replace('eprint ','')
-        ads_ex.xml_node(self.current_abstract,'electronic_id',electronic_id)
-
-        number_pages = 0
-        ads_ex.xml_node(self.current_abstract,'number_pages',str(number_pages))
-
-        databases = set()
-        try:
-            field = ads_ex.UNICODE_HANDLER.ent2xml(record['keywords'])
-        except:
+    if len(field) > 0:
+        adsr.arxiv_categories = ads_ex.xml_node(adsr.current_abstract, 'arxivcategories')
+        all_keywords = {}
+        keywords = []
+        main_category = 'main'
+        for keyword in field.split(';'):
+            keyword = keyword.strip()
             try:
-                field = record['keywords']
+                category = ArtDefs.cat2channel[keyword]
             except:
                 pass
-        if len(field) > 0:
-            self.arxiv_categories = ads_ex.xml_node(self.current_abstract,'arxivcategories')
-            all_keywords = {}
-            keywords = []
-            main_category = 'main'
-            for keyword in field.split(';'):
-                keyword = keyword.strip()
+            else:
+                ads_ex.xml_node(adsr.arxiv_categories, 'arxivcategory', category, {'type': main_category})
+                if category.find('.') >= 0:
+                    category = category.split('.')[0]
                 try:
-                    category = ArtDefs.cat2channel[keyword]
+                    databases.add(ads_ex.ARXIV_DATABASE[category])
                 except:
                     pass
-                else:
-                    ads_ex.xml_node(self.arxiv_categories,'arxivcategory',category,{'type': main_category})
-                    if category.find('.') >= 0:
-                        category = category.split('.')[0]
-                    try:
-                        databases.add(ads_ex.ARXIV_DATABASE[category])
-                    except:
-                        pass
-                    main_category = None
-                    keywords.append((keyword, kw_normalizer.get_normalized_keyword(keyword)))
-        all_keywords.setdefault('arXiv',[]).extend(keywords)
-        ads_ex.add_keywords(self.current_abstract, all_keywords)
+                main_category = None
+                keywords.append((keyword, kw_normalizer.get_normalized_keyword(keyword)))
+    all_keywords.setdefault('arXiv', []).extend(keywords)
+    ads_ex.add_keywords(adsr.current_abstract, all_keywords)
+
+    pubnote = "; ".join([x.replace('\n', '') for x in record['comments']])
+    ads_ex.xml_node(adsr.current_abstract,'pubnote', pubnote.replace('  ', ' '))
+
+    # Properties
+    adsr.current_properties = ads_ex.xml_node(adsr.current_record, 'metadata',
+                                              properties={'type': 'properties',
+                                                          'primary': 'False',
+                                                          'origin': 'ADS metadata',
+                                                          'alternate_journal': 'False'})
+
+    ads_ex.xml_node(adsr.current_properties, 'JSON_timestamp', ' dummy string')
+    ads_ex.add_databases(adsr.current_properties, databases)
+    ads_ex.xml_node(adsr.current_properties, 'pubtype', 'eprint')
+    ads_ex.xml_node(adsr.current_properties, 'private', 0)
+    ads_ex.xml_node(adsr.current_properties, 'ocrabstract', 0)
+    preprint_id = electronic_id.replace('arXiv:', '')
+    ads_ex.xml_node(adsr.current_properties, 'preprint', preprint_id)
+    ads_ex.xml_node(adsr.current_properties, 'nonarticle', 0)
+    ads_ex.xml_node(adsr.current_properties, 'refereed', 0)
+    ads_ex.xml_node(adsr.current_properties, 'openaccess', 1)
+    ads_ex.xml_node(adsr.current_properties, 'eprint_openaccess', 1)
+    ads_ex.xml_node(adsr.current_properties, 'pub_openaccess', 0)
+    ads_ex.xml_node(adsr.current_properties, 'note', 0)
+    ads_ex.xml_node(adsr.current_properties, 'ads_openaccess', 0)
+
+    # Relations
+    adsr.current_relations = ads_ex.xml_node(adsr.current_record, 'metadata',
+                                             properties={'type': 'relations',
+                                                         'primary': 'False',
+                                                         'origin': 'ADS metadata',
+                                                         'alternate_journal': 'False'})
+
+    ads_ex.xml_node(adsr.current_relations, 'preprintid', preprint_id, {'ecode': bibcode})
+    ads_ex.xml_node(adsr.current_relations, 'alternates', None)
+
+    adsr.linksection = ads_ex.xml_node(adsr.current_relations, 'links')
+    ads_ex.xml_node(adsr.linksection, 'link',
+                    properties={'type': 'preprint',
+                                'url': record['properties']['HTML'],
+                                'access': 'open'})
+
+    return adsr
 
 
-        pubnote = "; ".join([x.replace('\n','') for x in record['comments']])
-        ads_ex.xml_node(self.current_abstract,'pubnote',pubnote.replace('  ',' '))
-        
-
-
-        # Properties
-        self.current_properties = ads_ex.xml_node(self.current_record, 'metadata',
-                                         properties={'type': 'properties',
-                                                     'primary':'False',
-                                                     'origin': 'ADS metadata',
-                                                     'alternate_journal':'False'})
-
-        ads_ex.xml_node(self.current_properties,'JSON_timestamp','dummy string')
-        ads_ex.add_databases(self.current_properties,databases)
-        ads_ex.xml_node(self.current_properties,'pubtype','eprint')
-        ads_ex.xml_node(self.current_properties,'private',0)
-        ads_ex.xml_node(self.current_properties,'ocrabstract',0)
-        preprint_id = electronic_id.replace('arXiv:','')
-        ads_ex.xml_node(self.current_properties,'preprint',preprint_id)
-        ads_ex.xml_node(self.current_properties,'nonarticle',0)
-        ads_ex.xml_node(self.current_properties,'refereed',0)
-        ads_ex.xml_node(self.current_properties,'openaccess',1)
-        ads_ex.xml_node(self.current_properties,'eprint_openaccess',1)
-        ads_ex.xml_node(self.current_properties,'pub_openaccess',0)
-        ads_ex.xml_node(self.current_properties,'note',0)
-        ads_ex.xml_node(self.current_properties,'ads_openaccess',0)
-
-
-        # Relations
-        self.current_relations = ads_ex.xml_node(self.current_record, 'metadata',
-                                       properties={'type': 'relations',
-                                                   'primary':'False',
-                                                   'origin': 'ADS metadata',
-                                                   'alternate_journal':'False'})
-
-        ads_ex.xml_node(self.current_relations,'preprintid',preprint_id,{'ecode':bibcode})
-        ads_ex.xml_node(self.current_relations,'alternates',None)
-
-        self.linksection = ads_ex.xml_node(self.current_relations,'links')
-        ads_ex.xml_node(self.linksection,'link',
-                        properties={'type':'preprint',
-                                    'url':record['properties']['HTML'],
-                                    'access':'open'})
-
-        # Done
 #def main():
 #
 #    import gzip

--- a/aip/tasks.py
+++ b/aip/tasks.py
@@ -106,14 +106,13 @@ def task_merge_metadata(record):
 @app.task(queue='direct:merge-metadata')
 def task_merge_arxiv_direct(record):
 
-    modrec = ArXivDirect.adsDirectRecord('full','XML',cacheLooker=False)
-    modrec.addDirect(record)
+    modrec = ArXivDirect.add_direct(record)
     output = read_records.xml_to_dict(modrec.root)
     e = enforce_schema.Enforcer()
     export = e.ensureList(output['records']['record'])
     newrec = []
     for r in export:
-        rec = e.enforceTopLevelSchema(record=r,JSON_fingerprint='Fake')
+        rec = e.enforceTopLevelSchema(record=r, JSON_fingerprint='Fake')
         newrec.append(rec)
     result = merger.mergeRecords(newrec)
     for r in result:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/adsabs/ADSPipelineUtils.git@v1.0.0
-git+https://github.com/seasidesparrow/adsabs-pyingest.git
+git+https://github.com/adsabs/adsabs-pyingest.git
 alembic==0.9.1
 celery==4.1.1
 ConcurrentLogHandler==0.9.1


### PR DESCRIPTION
ArXivDirect no longer subclasses ADSRecords, the subclass is not available in continuous integration environment
increased compliance with pep8