### PR TITLE
Adjust Classic ingest entry_date for local vs UTC time

### DIFF
--- a/aip/classic/solr_adapter.py
+++ b/aip/classic/solr_adapter.py
@@ -4,6 +4,7 @@ import os
 import sys
 import re
 import traceback
+import datetime
 
 
 from adsputils import setup_logging, get_date, date2solrstamp
@@ -276,8 +277,9 @@ class SolrAdapter(object):
   
   @staticmethod
   def _entry_date(ADS_record):
-    d = ADS_record.get('entry_date', None)     
-    return {'entry_date': date2solrstamp(d and get_date(d) or get_date())}
+    d = ADS_record.get('entry_date', None)
+    # Add one day to entry date to account for local (Classic) vs. UTC (direct ingest) time
+    return {'entry_date': date2solrstamp(d and get_date(d)+datetime.timedelta(days=1) or get_date()+datetime.timedelta(days=1))}
 
   @staticmethod
   def _year(ADS_record):

--- a/aip/classic/solr_adapter.py
+++ b/aip/classic/solr_adapter.py
@@ -279,7 +279,7 @@ class SolrAdapter(object):
   def _entry_date(ADS_record):
     d = ADS_record.get('entry_date', None)
     # Add one day to entry date to account for local (Classic) vs. UTC (direct ingest) time
-    return {'entry_date': date2solrstamp(d and get_date(d)+datetime.timedelta(days=1) or get_date()+datetime.timedelta(days=1))}
+    return {'entry_date': date2solrstamp(d and get_date(d)+datetime.timedelta(days=1) or get_date())}
 
   @staticmethod
   def _year(ADS_record):

--- a/tests/classic/test_solr_adapter.py
+++ b/tests/classic/test_solr_adapter.py
@@ -38,7 +38,7 @@ class TestSolrAdapter(unittest.TestCase):
          'doctype_facet_hier': [u'0/Non-Article', u'1/Non-Article/Catalog'],
          'doi': [u'doi:\xc5\xbd\xc5\xa0\xc4\x8c\xc5\x98\xc4\x8e\xc5\xa4\xc5\x87:123456789'],
          'email': [u'-', u'anders@email.com', u'-'],
-         'entry_date': '2003-03-21T00:00:00.000000Z',
+         'entry_date': '2003-03-22T00:00:00.000000Z',
          'first_author': u"t'Hooft, van X",
          'first_author_facet_hier': [u'0/T Hooft, V', u"1/T Hooft, V/t'Hooft, van X"],
          'first_author_norm': u'T Hooft, V',
@@ -68,7 +68,7 @@ class TestSolrAdapter(unittest.TestCase):
         self.assertEquals(r, {
             "first_author": u"Kurtz, Michael J.",
         #    "links_data": [u"{\"title\":\"\",\"type\":\"spires\",\"instances\":\"\"}", "{\"title\":\"\",\"type\":\"electr\",\"instances\":\"\"}", "{\"title\":\"\",\"type\":\"spires\",\"instances\":\"\"}"],
-            "entry_date": '2003-03-21T00:00:00.000000Z', 
+            "entry_date": '2003-03-22T00:00:00.000000Z',
             "first_author_norm": u"Kurtz, M", 
             "year": u"2000", 
             "bibcode": u"2000A&AS..143...41K_test", 
@@ -179,7 +179,7 @@ class TestSolrAdapter(unittest.TestCase):
             'date':     u'2014-06-01T00:00:00.000000Z',
             'bibstem': [u'arXiv', u'arXiv1406'],
             'bibstem_facet': u'arXiv',
-            'entry_date': '2003-02-21T00:00:00.000000Z',
+            'entry_date': '2003-02-22T00:00:00.000000Z',
             'pubdate' : u'2014-06-00',
             'doctype': u'article',
             
@@ -249,7 +249,7 @@ class TestSolrAdapter(unittest.TestCase):
             'date': u'2014-06-01T00:00:00.000000Z',
             'bibstem': [u'arXiv', u'arXiv1406'],
             'bibstem_facet': u'arXiv',
-            'entry_date': '2003-02-21T00:00:00.000000Z',
+            'entry_date': '2003-02-22T00:00:00.000000Z',
             'pubdate': u'2014-06-00',
             'doctype': u'article',
 
@@ -319,7 +319,7 @@ class TestSolrAdapter(unittest.TestCase):
             'date': u'2018-07-30T00:30:00.000000Z',
             'bibstem': [u'arXiv', u'arXiv1807'],
             'bibstem_facet': u'arXiv',
-            'entry_date': '2018-07-30T00:00:00.000000Z',
+            'entry_date': '2018-07-31T00:00:00.000000Z',
             'pubdate': u'2018-07-30',
             'doctype': u'article',
 
@@ -402,7 +402,7 @@ class TestSolrAdapter(unittest.TestCase):
             'date': u'1968-09-01T00:00:00.000000Z',
             'bibstem': [u'NuPhB', u'NuPhB...7'],
             'bibstem_facet': u'NuPhB',
-            'entry_date': '2004-06-09T00:00:00.000000Z',
+            'entry_date': '2004-06-10T00:00:00.000000Z',
             'pubdate': u'1968-09-00',
             'doctype': u'article',
 
@@ -474,7 +474,7 @@ class TestSolrAdapter(unittest.TestCase):
             'date': u'2018-02-01T00:00:00.000000Z',
             'bibstem': [u'ascl', u'ascl.soft'],
             'bibstem_facet': u'ascl.soft',
-            'entry_date': '2004-06-09T00:00:00.000000Z',
+            'entry_date': '2004-06-10T00:00:00.000000Z',
             'pubdate': u'2018-02-00',
             'doctype': u'software',
 
@@ -539,7 +539,7 @@ class TestSolrAdapter(unittest.TestCase):
             'date': u'1988-04-01T00:00:00Z',
             'bibstem': [u'Sci', u'Sci...240'],
             'bibstem_facet': u'Sci',
-            'entry_date': '2002-06-26T00:00:00.000000Z',
+            'entry_date': '2002-06-27T00:00:00.000000Z',
             'pubdate': u'1988-04-00',
             'date': u'1988-04-01T00:00:00.000000Z',
             'doctype': u'article',

--- a/tests/classic/test_tasks.py
+++ b/tests/classic/test_tasks.py
@@ -70,6 +70,7 @@ class TestWorkers(unittest.TestCase):
 
             out = copy.deepcopy(mergerdata.MERGEDRECS['2015ApJ...815..133S'])
             out['id'] = 1
+            out['entry_date'] = '2003-01-02T00:00:00.000000Z'
 
             tasks.task_merge_metadata(ADSRECORDS['2015ApJ...815..133S'])
             self.assertTrue(next_task.called)


### PR DESCRIPTION
The Classic pipeline runs on local time but the rest of the pipelines run on UTC. Add 1 day to dates coming from the Classic pipeline to account for this difference.