### PR TITLE
 	modified:   aip/tasks.py to reduce logging from direct ingest

### DIFF
--- a/aip/tasks.py
+++ b/aip/tasks.py
@@ -136,7 +136,7 @@ def task_merge_arxiv_direct(record):
         r = solr_adapter.SolrAdapter.adapt(r)
         solr_adapter.SolrAdapter.validate(r)
         task_output_direct.delay(r)
-        logger.info('direct ingest processed bibcode %s', record['bibcode'])
+        logger.debug('direct ingest processed bibcode %s', record['bibcode'])
 
 
 @app.task(queue='output-results')


### PR DESCRIPTION
Minor revision: Direct ingest logging will give notice on each bibcode only if debugging is set, otherwise .info logging will be limited to  information about how many records it has to process.   This will limit logging when millions of bibcodes are being reprocessed, which would otherwise produce several GB of logs.