### PR TITLE
Bugfix: control IntegrityError and AssertionError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test*txt
 venv
 *.pyc
 *~
+python


### PR DESCRIPTION
Control exceptions that stop processing the rest of the batch. Examples:

- AssertionError("identifier: multiple data-types in list: [u'2021MNRAS.500.4277J', u'2020MNRAS.tmp.3315J', u'10.1093/mnras/staa3476', u'2020arXiv200911251J', None]",)
- IntegrityError('(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "records_bibcode_key"\nDETAIL:  Key (bibcode)=(2020PhyOJ..13S..79.) already exists.\n',)