### PR TITLE
Allow for multiple DOIs in metadata records

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,7 +56,7 @@ MERGER_RULES = {
   'conf_metadata':        'originTrustMerger',
   'isbns':                'takeAll',
   'issns':                'takeAll',
-  'doi':                  'originTrustMerger',
+  'doi':                  'takeAll',
   'copyright':            'originTrustMerger',
   'comment':              'originTrustMerger',
   'pubnote':              'takeAll',


### PR DESCRIPTION
I order to populate the doi field with alternate DOIs (e.g. from arXiv) we need to change the policy for the field.
TODO: evaluate impact of this on metadata records which may have a mixture of "new" and "old" style DOIs