### PR TITLE
Ensure that DOIs are merged according to a priority policy

### DIFF
--- a/aip/classic/author_match.py
+++ b/aip/classic/author_match.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """
 This code was found in the github repository of Martin-Louis Bright (mlbright@gmail.com):
 https://github.com/mlbright/Assignment-Problem/blob/master/kuhn_munkres.py
@@ -51,15 +53,17 @@ import sys
 import re
 import numpy as np
 
-
+if sys.version_info[0] >= 3:
+    unicode = str
+    
 class HungarianGraph(object):
 
     def __init__(self, weights):
         self.weights = weights
         self.N  = len(self.weights)
 
-        self.lu = [max([self.weights[u][v] for v in xrange(self.N)]) for u in xrange(self.N)]  # start with trivial labels
-        self.lv = [0 for v in xrange(self.N)]
+        self.lu = [max([self.weights[u][v] for v in range(self.N)]) for u in range(self.N)]  # start with trivial labels
+        self.lv = [0 for v in range(self.N)]
 
         self.Mu = {}  # start with empty matching
         self.Mv = {}
@@ -69,7 +73,7 @@ class HungarianGraph(object):
         """ change the labels, and maintain min_slack. """
         for u in self.S:
             self.lu[u] -= val
-        for v in xrange(self.N):
+        for v in range(self.N):
             if v in self.T:
                 self.lv[v] += val
             else:
@@ -93,7 +97,7 @@ class HungarianGraph(object):
         """ augment the matching, possibly improving the labels on the way. """
         while True:
             # select edge (u,v) with u in S, v not in T and min slack
-            ((val, u), v) = min([(self.min_slack[v], v) for v in xrange(self.N) if v not in self.T])
+            ((val, u), v) = min([(self.min_slack[v], v) for v in range(self.N) if v not in self.T])
             assert u in self.S
             if val > 0:        
                 self.improve_labels(val)
@@ -109,7 +113,7 @@ class HungarianGraph(object):
                 u1 = self.Mv[v]                      # matched edge, 
                 assert not u1 in self.S
                 self.S.add(u1)
-                for v in xrange(self.N): # maintain min_slack
+                for v in range(self.N): # maintain min_slack
                     if v not in self.T and self.min_slack[v][0] > self.slack(u1,v):
                         self.min_slack[v] = [self.slack(u1,v), u1]
             else:
@@ -125,10 +129,10 @@ class HungarianGraph(object):
         """
 
         while len(self.Mu) < self.N:
-            u0 = [u for u in xrange(self.N) if u not in self.Mu][0] # choose free vertex u0
+            u0 = [u for u in range(self.N) if u not in self.Mu][0] # choose free vertex u0
             self.S = set([u0])
             self.T = {}
-            self.min_slack = [[self.slack(u0,v), u0] for v in xrange(self.N)]
+            self.min_slack = [[self.slack(u0,v), u0] for v in range(self.N)]
             self.augment()
         # val. of matching is total edge weight
         val = sum(self.lu) + sum(self.lv)
@@ -414,7 +418,7 @@ def is_suitable_match(a1, a2):
 #   'Accomazzi, A. (CfA); Krutz, M. (SAO); Grant Stern, C (Harvard)'
 
 if __name__ == "__main__":
-
+    
     if len(sys.argv) != 3:
         sys.stderr.write("Usage: %s 'aut_string1' 'aut_string2'\n",
                          sys.argv[0]);
@@ -442,34 +446,34 @@ if __name__ == "__main__":
         f2.append({'name': {'western': name}, 'affiliations': [aff] if aff else []})
         a2aff += 1 if aff else 0
 
-    print "Aut1 struct:", f1
-    print "Aut2 struct:", f2
-    print "Number of names in aut1: ", a1aut
-    print "Number of names in aut2: ", a2aut
-    print "Number of affiliations in aut1: ", a1aff
-    print "Number of affiliations in aut2: ", a2aff
+    print("Aut1 struct:", f1)
+    print("Aut2 struct:", f2)
+    print("Number of names in aut1: ", a1aut)
+    print("Number of names in aut2: ", a2aut)
+    print("Number of affiliations in aut1: ", a1aff)
+    print("Number of affiliations in aut2: ", a2aff)
     
     if a1aut == a1aff:
-        print "all authors in aut1 have affiliations, we're done"
+        print("all authors in aut1 have affiliations, we're done")
         exit(0)
     elif a2aff == 0:
-        print "no affiliations present in aut2, we're done"
+        print("no affiliations present in aut2, we're done")
         exit(0)
     else:
-        print "will try to pick from", a2aff, "affiliations to assign to", a1aut - a1aff, "author names"
+        print("will try to pick from", a2aff, "affiliations to assign to", a1aut - a1aff, "author names")
 
     res = match_ads_author_fields(f1, f2)
     
     authors = []
     for author1, author2 in res:
-        print "considering:", author1, author2
+        print("considering:", author1, author2)
         if author1 and author2 and \
                 not author1['affiliations'] and \
                 author2['affiliations'] and \
                 is_suitable_match(author1, author2):
             author1['affiliations'] = author2['affiliations']
-            print "updated author affiliations:", author1
+            print("updated author affiliations:", author1)
         authors.append(author1)
                 
-    print "Final author structure:", authors
+    print("Final author structure:", authors)
 

--- a/aip/classic/author_match.py
+++ b/aip/classic/author_match.py
@@ -55,6 +55,7 @@ import numpy as np
 
 if sys.version_info[0] >= 3:
     unicode = str
+    xrange = range
     
 class HungarianGraph(object):
 
@@ -62,8 +63,8 @@ class HungarianGraph(object):
         self.weights = weights
         self.N  = len(self.weights)
 
-        self.lu = [max([self.weights[u][v] for v in range(self.N)]) for u in range(self.N)]  # start with trivial labels
-        self.lv = [0 for v in range(self.N)]
+        self.lu = [max([self.weights[u][v] for v in xrange(self.N)]) for u in xrange(self.N)]  # start with trivial labels
+        self.lv = [0 for v in xrange(self.N)]
 
         self.Mu = {}  # start with empty matching
         self.Mv = {}
@@ -73,7 +74,7 @@ class HungarianGraph(object):
         """ change the labels, and maintain min_slack. """
         for u in self.S:
             self.lu[u] -= val
-        for v in range(self.N):
+        for v in xrange(self.N):
             if v in self.T:
                 self.lv[v] += val
             else:
@@ -97,7 +98,7 @@ class HungarianGraph(object):
         """ augment the matching, possibly improving the labels on the way. """
         while True:
             # select edge (u,v) with u in S, v not in T and min slack
-            ((val, u), v) = min([(self.min_slack[v], v) for v in range(self.N) if v not in self.T])
+            ((val, u), v) = min([(self.min_slack[v], v) for v in xrange(self.N) if v not in self.T])
             assert u in self.S
             if val > 0:        
                 self.improve_labels(val)
@@ -113,7 +114,7 @@ class HungarianGraph(object):
                 u1 = self.Mv[v]                      # matched edge, 
                 assert not u1 in self.S
                 self.S.add(u1)
-                for v in range(self.N): # maintain min_slack
+                for v in xrange(self.N): # maintain min_slack
                     if v not in self.T and self.min_slack[v][0] > self.slack(u1,v):
                         self.min_slack[v] = [self.slack(u1,v), u1]
             else:
@@ -129,10 +130,10 @@ class HungarianGraph(object):
         """
 
         while len(self.Mu) < self.N:
-            u0 = [u for u in range(self.N) if u not in self.Mu][0] # choose free vertex u0
+            u0 = [u for u in xrange(self.N) if u not in self.Mu][0] # choose free vertex u0
             self.S = set([u0])
             self.T = {}
-            self.min_slack = [[self.slack(u0,v), u0] for v in range(self.N)]
+            self.min_slack = [[self.slack(u0,v), u0] for v in xrange(self.N)]
             self.augment()
         # val. of matching is total edge weight
         val = sum(self.lu) + sum(self.lv)
@@ -306,7 +307,7 @@ def normalize_authors (a1, a2):
     author2 += ','
     # now append segments from first and middle names
     ntokens = min(len(pa1),len(pa2))
-    for i in range(ntokens):
+    for i in xrange(ntokens):
         tlen = min(len(pa1[i]), len(pa2[i]))
         author1 += ' ' + pa1[i][:tlen]
         author2 += ' ' + pa2[i][:tlen]
@@ -326,12 +327,12 @@ def match_author_lists (al1, al2, impl=None):
     # we work with a square matrix, so enforce same
     # dimension for both arrays
     n = max(len(al1), len(al2))
-    m = [[-1 for i in range(n)] for j in range(n)]
+    m = [[-1 for i in xrange(n)] for j in xrange(n)]
 
     # now compute cost matrix
-    for i in range(n):
+    for i in xrange(n):
         s1 = al1[i] if i < len(al1) else ''
-        for j in range(n):
+        for j in xrange(n):
             s2 = al2[j] if j < len(al2) else ''
             # note: we can't cache the normalized versions
             # of author names because they are computed in pairs
@@ -389,9 +390,9 @@ def match_ads_author_fields (f1, f2, impl=None):
     # make sure there are enough elements in f2
     if len(f2) < len(f1):
         # print "Extending array2 with", len(f1) - len(f2), "additional elements"
-        f2.extend([None for i in range(len(f1) - len(f2))])
+        f2.extend([None for i in xrange(len(f1) - len(f2))])
 
-    return [ (f1[i],f2[mapping[i]]) for i in range(len(f1)) ]
+    return [ (f1[i],f2[mapping[i]]) for i in xrange(len(f1)) ]
 
 
 def is_suitable_match(a1, a2):

--- a/aip/classic/merger.py
+++ b/aip/classic/merger.py
@@ -222,6 +222,7 @@ class Merger:
 
 
   def takeAll(self,field):
+    """Takes all values for a field, concatenating them in a unique array"""
     def deDuplicated(L):
       #This will still consider 'origin' in the comparison
       result = []
@@ -236,6 +237,49 @@ class Merger:
         r.extend(i[field])
 
     return deDuplicated(r)
+
+
+  def takeAllByPriority(self,field):
+    def deDuplicated(L):
+      result = []
+      for i in L:
+        if i not in result:
+          result.append(i)
+      return result
+
+    data = [ (i[field],i['tempdata']) for i in self.blocks if field in i]
+    for f in data:
+      p = self._getOriginPriority(f,field)
+      f[1]['priority'] = p
+
+    # sort by priority
+    data.sort(key=lambda f: f[1]['priority'], reverse=True)
+    # flatten the list since each element can be an array
+    r = []
+    for i in data:
+        if i[0]:
+            r.extend(i[0])
+
+    return deDuplicated(r)
+
+
+  def _getOriginPriority(self,f,field):
+    """Returns the priority score of a metdata record for a given field"""
+    if not f:
+      return 0
+    if field not in self.priorities:
+      p = self.priorities['default']
+    else:
+      p = self.priorities[field]
+    # pick the origin with the highest priority for each record
+    origins = f[1]['origin'].split('; ')
+    o = origins.pop()
+    for i in origins:
+      o = i if p.get(i.upper(),0) >= p.get(o1.upper(),0) else o
+    # if origin not defined, default to 'PUBLISHER'
+    P = p.get(o.upper(),p.get('PUBLISHER',0))
+    return P
+
 
   def _getBestOrigin(self,f1,f2,field):
     #If one of the two fields has empty content, return the one with content

--- a/aip/classic/merger.py
+++ b/aip/classic/merger.py
@@ -21,7 +21,7 @@ def mergeRecords(records):
         blocks = e.ensureList(r['metadata'])
         #Multiply defined blocks need merging.
         metadatablockCounter = collections.Counter([i['tempdata']['type'] for i in blocks])
-        needsMerging = dict([(k,[]) for k,v in metadatablockCounter.iteritems() if v>1])
+        needsMerging = dict([(k,[]) for k,v in metadatablockCounter.items() if v>1])
 
         completeMetadata = {}
         #First pass: Add the singly defined blocks to the complete record
@@ -33,7 +33,7 @@ def mergeRecords(records):
                 needsMerging[_type].append(b)
 
     #Second pass: Merge the multiple defined blocks
-    for _type,blocks in needsMerging.iteritems():
+    for _type,blocks in needsMerging.items():
         m = Merger(blocks)
         m.merge()
         completeMetadata.update({
@@ -111,8 +111,8 @@ class Merger:
       for block in self.blocks:
         if fieldName in block:
           fieldsHist[fieldName] += 1
-    singleDefinedFields = [k for k,v in fieldsHist.iteritems() if v==1]
-    multipleDefinedFields = [k for k,v in fieldsHist.iteritems() if v>1]
+    singleDefinedFields = [k for k,v in fieldsHist.items() if v==1]
+    multipleDefinedFields = [k for k,v in fieldsHist.items() if v>1]
     r = {}
     # First pass: construct the record from singly defined fields
     for field in singleDefinedFields:
@@ -123,7 +123,7 @@ class Merger:
     for field in multipleDefinedFields:
       try:
         r[field] = self._dispatcher(field)
-      except Exception, err:
+      except Exception as err:
         self.logger.error('Error with merger dispatcher on %s: %s' % (field,err))
         raise
     self.block = r

--- a/config.py
+++ b/config.py
@@ -319,19 +319,19 @@ _PRIORITIES_REFERENCES = {
 
 PRIORITIES = {
   'default': dict((source, score)
-    for score, sources in _PRIORITIES_DEFAULT.iteritems()
+    for score, sources in _PRIORITIES_DEFAULT.items()
     for source in sources),
   'journals': dict((source, score)
-    for score, sources in _PRIORITIES_JOURNALS.iteritems()
+    for score, sources in _PRIORITIES_JOURNALS.items()
     for source in sources),
   'authors': dict((source, score)
-    for score, sources in _PRIORITIES_AUTHORS.iteritems()
+    for score, sources in _PRIORITIES_AUTHORS.items()
     for source in sources),
   'references': dict((source, score)
-    for score, sources in _PRIORITIES_REFERENCES.iteritems()
+    for score, sources in _PRIORITIES_REFERENCES.items()
     for source in sources),
   'abstracts': dict((source, score)
-    for score, sources in _PRIORITIES_ABSTRACTS.iteritems()
+    for score, sources in _PRIORITIES_ABSTRACTS.items()
     for source in sources),
 }
 

--- a/config.py
+++ b/config.py
@@ -56,7 +56,7 @@ MERGER_RULES = {
   'conf_metadata':        'originTrustMerger',
   'isbns':                'takeAll',
   'issns':                'takeAll',
-  'doi':                  'takeAll',
+  'doi':                  'takeAllByPriority',
   'copyright':            'originTrustMerger',
   'comment':              'originTrustMerger',
   'pubnote':              'takeAll',

--- a/tests/classic/test_merger.py
+++ b/tests/classic/test_merger.py
@@ -75,6 +75,38 @@ class TestMerger(unittest.TestCase):
         expectedResults = { 'titles': [ 'Publisher title' ], 'altpublications': [] }
         self.assertEqual(results,expectedResults)
 
+    def test_doiMerger(self):
+        # DOI are merged in priority list, so that the publisher one is always first
+        B1 = {'tempdata':{'origin':'PUBLISHER','type':'general'}}
+        B2 = {'tempdata':{'origin':'ARXIV','type':'general'}}
+        B3 = {'tempdata':{'origin':'SIMBAD','type':'general'}}
+
+        # 2022NatAs...6..331D
+        B1['doi'] = [ '10.1038/s41550-021-01558-y' ]
+        B2['doi'] = [ '10.48550/arXiv.2201.05617' ]
+        B3['doi'] = [ '10.1038/s41550-021-01558-y' ]
+
+        blocks = [B1,B2]
+        m = merger.Merger(blocks)
+        m.merge()
+        results = m.block
+
+        expectedResults = { 'doi': [ '10.1038/s41550-021-01558-y', '10.48550/arXiv.2201.05617' ], 'altpublications': [] }
+        self.assertEqual(results,expectedResults)
+        blocks = [B2,B1]
+        m = merger.Merger(blocks)
+        m.merge()
+        results = m.block
+        expectedResults = { 'doi': [ '10.1038/s41550-021-01558-y', '10.48550/arXiv.2201.05617' ], 'altpublications': [] }
+        self.assertEqual(results,expectedResults)
+
+        blocks = [B2,B1,B3]
+        m = merger.Merger(blocks)
+        m.merge()
+        results = m.block
+        expectedResults = { 'doi': [ '10.1038/s41550-021-01558-y', '10.48550/arXiv.2201.05617' ], 'altpublications': [] }
+        self.assertEqual(results,expectedResults)
+
 
     def test_want_datetime(self):
         m = merger.Merger([])


### PR DESCRIPTION
With the use of arXiv DOIs, we are starting to have records in ADS with multiple DOIs.
Our system is able to deal with them (the `doi` field in SOLR is multi-valued), but we want the publisher DOI (in particular the VOR) to be the first one in the list, since this one is used to link to the article in the UI.

This PR changes the policy for merging DOI metadata by adding a priority sort based on the origin of the relevant metadata.