### PR TITLE
Updated github_action to use alt python-2.7 install method.

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -5,14 +5,39 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
+    # - uses: actions/setup-python@v2
+    #   with:
+    #     python-version: 2.7
+    - name: install python2
+      run: |
+        sudo apt-get update
+        sudo apt-get install python2.7 -y
+        sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
 
+        venv_base_path="/tmp/python27/venv"
+        venv_dir="bin"
+
+        echo "Bootstrapping pip"
+
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+        python get-pip.py
+        rm -f get-pip.py
+
+        echo "Installing virtualenv"
+        python -m pip install virtualenv
+
+        python -m virtualenv ${venv_base_path}
+
+        source ${venv_base_path}/${venv_dir}/activate
+
+        python -m pip --no-python-version-warning --disable-pip-version-check install --upgrade pip setuptools
+
+        echo "${venv_base_path}/${venv_dir}" >> $GITHUB_PATH
+        
     - name: Install dependencies
       run: |
         python -m pip install --upgrade setuptools pip

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -16,6 +16,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install python2.7 -y
+        sudo apt-get install python2.7-dev -y
         sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
 
         venv_base_path="/tmp/python27/venv"
@@ -37,7 +38,7 @@ jobs:
         python -m pip --no-python-version-warning --disable-pip-version-check install --upgrade pip setuptools
 
         echo "${venv_base_path}/${venv_dir}" >> $GITHUB_PATH
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade setuptools pip

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -9,9 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # - uses: actions/setup-python@v2
-    #   with:
-    #     python-version: 2.7
     - name: install python2
       run: |
         sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ADSimportpipeline
 
-[![Build Status](https://travis-ci.org/adsabs/ADSimportpipeline.svg?branch=master)](https://travis-ci.org/adsabs/ADSimportpipeline)
+[![GitHub Actions CI](https://github.com/adsabs/ADSImportPipeline/actions/workflows/python_actions.yml/badge.svg)](https://github.com/adsabs/ADSImportPipeline/actions/workflows/python_actions.yml)
 [![Coverage Status](https://coveralls.io/repos/adsabs/ADSimportpipeline/badge.svg?branch=master)](https://coveralls.io/r/adsabs/ADSimportpipeline)
 
 ## Overview


### PR DESCRIPTION
`setup-python` no longer supports `python-2.7` required to run `ImportPipeline` this PR updates the github action to manually install python.