### PR TITLE
new doctype support

### DIFF
--- a/aip/classic/solr_adapter.py
+++ b/aip/classic/solr_adapter.py
@@ -639,6 +639,8 @@ doctype_dict = {
   'catalog':       'Catalog',
   'editorial':     'Editorial',
   'dataset':       'Dataset',
+  'instrument':    'Instrument',
+  'service':       'Service',
   'misc':          'Other'
 }
 


### PR DESCRIPTION
Two new non-article doctypes: `instrument` and `service` 